### PR TITLE
(minor) addition of avatar testing chamber phone

### DIFF
--- a/AGBBase.toml
+++ b/AGBBase.toml
@@ -113,3 +113,10 @@ game_objects = [
     { name = "Nevermet Host Functionality" },
     { name = "Nevermet" }
 ]
+
+[[block]]
+friendly_name = "Avatar Testing Chamber"
+world_id = "wrld_a5e9ec13-36b1-4e63-ae0c-dab9023401f9"
+game_objects = [
+    { name = "Neverphone" }
+]


### PR DESCRIPTION
removes Nevermet phone from Ziggors Avatar Testing Chamber

![VRChat_2023-12-07_16-32-45 328_1280x720](https://github.com/AdGoBye/AdGoBye-Blocklists/assets/20288698/6b9e6f00-dfef-4310-92a5-c1d31a7fd4d4)
