### PR TITLE
added Room of the rain block lists

### DIFF
--- a/AGBBase.toml
+++ b/AGBBase.toml
@@ -109,3 +109,12 @@ world_id = "wrld_a5e9ec13-36b1-4e63-ae0c-dab9023401f9"
 game_objects = [
     { name = "Neverphone" }
 ]
+
+[[block]]
+friendly_name = "The room of the rain"
+world_id = "wrld_fae3fa95-bc18-46f0-af57-f0c97c0ca90a"
+game_objects = [
+    { name = "Neverphone" }, # removes the phone
+    { name = "Horizontal_poster"}, # removes the horizontal nevermet poster
+    { name = "Quad (1)"} # removes the vertical SlimeVR poster
+]

--- a/AGBCommunity.toml
+++ b/AGBCommunity.toml
@@ -58,3 +58,14 @@ game_objects = [
     { name = "TV Prefab UNIQUE", position = { x = -4.366071, y = 3.072498, z = -54.21133 } },
     { name = "Poster (9)", parent = { name = "Poster (9)" } }
 ]
+
+[[block]]
+friendly_name = "The room of the rain"
+world_id = "wrld_fae3fa95-bc18-46f0-af57-f0c97c0ca90a"
+game_objects = [
+    { name = "Neverphone" },
+    { name = "Patreon ui", parent = { name = "Patreon Things" } }, # removes the UI with patreon only settings
+    { name = "Patreon panel", parent = { name = "Patreon Things" } }, # removes the auto scrolling image board of patreon subscribers
+    { name = "Patreon texture Changer", parent = { name = "Patreon Things" } }, # removes texture changer for the patreon panel to avoid Udon exceptions for missing refrences
+    { name = "Patreon texture Changer (1)", parent = { name = "Patreon Things" } },
+]


### PR DESCRIPTION
This PR addresses a lot of advertisements in Room of the rain such as the 

SlimeVR Poster:

![Medal_yJll5vCeMw](https://github.com/AdGoBye/AdGoBye-Blocklists/assets/20288698/1d41ffd0-504a-473a-8e58-031b6627f97b)


Nevermet Phone:

![Medal_26z7JizWBO](https://github.com/AdGoBye/AdGoBye-Blocklists/assets/20288698/f183ddd0-00eb-4c5a-9f38-390192012086)

Nevermet Horizontal Poster:


![Medal_qVYZetXOTm](https://github.com/AdGoBye/AdGoBye-Blocklists/assets/20288698/de64a0b3-b71a-475f-9289-accc5abe2b7b)


And the patreon only menus and scrolling info
![Medal_u1h59IJ3lO](https://github.com/AdGoBye/AdGoBye-Blocklists/assets/20288698/88401c9e-4bbe-4896-a6dc-fba55189bfee)

![image](https://github.com/AdGoBye/AdGoBye-Blocklists/assets/20288698/3f21e621-f999-4016-a6bd-b36e9da08d2c)
